### PR TITLE
Apple Silicon (M1 MacBook) 対応

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.24.1"
+      version = "~> 3.30.0"
     }
   }
 }


### PR DESCRIPTION
### 概要

Fix: #2 

#### 動作確認済み

- [x] terraform apply で正常にEC2インスタンスなどのAWS環境が構築できること
- [x] terraform destroy で正常に構築したAWS環境が削除できること

### ログ

```sh
$ terraform --version
Terraform v1.1.9
on darwin_arm64

$ terraform init         
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 3.24.1"...
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/aws v3.24.1 does not have a package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.
╵

$ terraform --version
Terraform v1.1.9
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v3.30.0
```

P.S. 気軽に terraform でISUCONの練習環境が作れて助かりました！
リポジトリの公開ありがとうございます！