### PR TITLE
鍵について ssh-rsa ではなく Ed25519 を使う前提に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ https://qiita.com/momotaro98/items/24cec11fc050c014057f
 専用鍵がなければ以下のようにして鍵を生成する。
 
 ```
-ssh-keygen -t rsa -b 4096 -C "isucon key" -f isucon_id_rsa
+ssh-keygen -t ed25519 -C "isucon_key" -f isucon_id_ed25519
 ```
 
-公開鍵を`isucon_id_rsa.pub`の名前で以下の場所に置く。
+公開鍵を`isucon_id_ed25519.pub`の名前で以下の場所に置く。
 
 ```
-modules/credential/isucon_id_rsa.pub
+modules/credential/isucon_id_ed25519.pub
 ```
 
 terraformで構築後、以下のような設定でEC2へSSHできる。
@@ -33,7 +33,7 @@ Host isucon-practice-ec2
   HostName your_EC2_public_name
   Port 22
   User ubuntu
-  IdentityFile ~/.ssh/isucon_id_rsa
+  IdentityFile ~/.ssh/isucon_id_ed25519
   IdentitiesOnly yes
   RequestTTY yes
   RemoteCommand sudo su - isucon

--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -1,1 +1,1 @@
-credential/*id_rsa*
+credential/*id_ed25519*

--- a/modules/ec2/instances.tf
+++ b/modules/ec2/instances.tf
@@ -1,6 +1,6 @@
 resource "aws_key_pair" "participant-key" {
   key_name   = "isucon_key"
-  public_key = file("./modules/credential/isucon_id_rsa.pub")
+  public_key = file("./modules/credential/isucon_id_ed25519.pub")
 }
 
 resource "aws_instance" "participant-instance" {


### PR DESCRIPTION
鍵を生成する際、最近はrsaではないより強いアルゴリズムを使うことが推奨されています。
GitHubではドキュメントでed25519を使うようになっています。
[Generating a new SSH key and adding it to the ssh-agent - GitHub Docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)

ということでGitHubのドキュメントに揃えてed25519を使う前提に調整してみました。
（もちろん、READMEでは `-b 4096` のオプションで鍵を生成することが記されているのでオプションなしで発行するよりかはマシだと思います）

影響としては元々 `isucon_id_rsa.pub` みたいな名前で利用していた場合 `modules/ec2/instances.tf` に書かれているパスと名前が一致しなくて terraform plan がこけるようになるのでファイル名を揃える必要があります。